### PR TITLE
chore: update brakeman to 7.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
-    brakeman (7.0.2)
+    brakeman (7.1.0)
       racc
     builder (3.3.0)
     coderay (1.1.3)


### PR DESCRIPTION
## Summary
- upgrade brakeman to version 7.1.0 to resolve outdated dependency error

## Testing
- `bin/brakeman --no-pager`
- `bin/rails test` *(fails: cannot load such file -- test_helper)*

------
https://chatgpt.com/codex/tasks/task_e_6895f178a7008323bb9aa69934a7af3a